### PR TITLE
Feat: entity lock, entity spawn handling

### DIFF
--- a/client/client.lua
+++ b/client/client.lua
@@ -1025,6 +1025,8 @@ function StoreDeletedEntity(entity)
 		y = props.y,
 		z = props.z,
 		model = props.model,
+		name = props.name,
+		distance = 0.1
 	})
 end
 

--- a/ui/index.html
+++ b/ui/index.html
@@ -336,9 +336,12 @@
 					<button id="properties-add-to-db" class="add-remove-db">Add to DB</button>
 					<button id="properties-remove-from-db" class="add-remove-db">Remove from DB</button>
 				</div>
-				<div class="property">
+				<div class="property multiple">
 					<button id="properties-freeze">Freeze</button>
 					<button id="properties-unfreeze">Unfreeze</button>
+
+					<button id="properties-lock">Lock</button>
+					<button id="properties-unlock">Unlock</button>
 				</div>
 				<div class="property">
 					<div class="label">Position</div>
@@ -908,13 +911,13 @@
 						<td>No</td>
 					</tr>
 					<tr>
-						<td>Ymap</th>
+						<td>Ymap</td>
 						<td>Native map format used by GTA V/RDR2</td>
 						<td>Yes</td>
 						<td>Yes</td>
 					</tr>
 					<tr>
-						<td>Mlo</th>
+						<td>Mlo</td>
 						<td>Native map format used by GTA V/RDR2</td>
 						<td>Yes</td>
 						<td>Yes</td>

--- a/ui/script.js
+++ b/ui/script.js
@@ -1256,6 +1256,14 @@ function updatePropertiesMenu(data) {
 		document.getElementById('properties-freeze').style.display = 'block';
 	}
 
+	if (properties.isLocked) {
+		document.getElementById('properties-lock').style.display = 'none';
+		document.getElementById('properties-unlock').style.display = 'block';
+	} else {
+		document.getElementById('properties-unlock').style.display = 'none';
+		document.getElementById('properties-lock').style.display = 'block';
+	}
+
 	if (properties.isInGroup) {
 		document.querySelector('#properties-add-to-group').style.display = 'none';
 		document.querySelector('#properties-remove-from-group').style.display = 'block';
@@ -1526,6 +1534,8 @@ function updatePermissions(data) {
 
 	document.getElementById('properties-freeze').disabled = !permissions.properties.freeze;
 	document.getElementById('properties-unfreeze').disabled = !permissions.properties.freeze;
+	document.getElementById('properties-lock').disabled = !permissions.properties.freeze;
+	document.getElementById('properties-unlock').disabled = !permissions.properties.freeze;
 	document.getElementById('properties-x').disabled = !permissions.properties.position;
 	document.getElementById('properties-y').disabled = !permissions.properties.position;
 	document.getElementById('properties-z').disabled = !permissions.properties.position;
@@ -1922,6 +1932,18 @@ window.addEventListener('load', function() {
 
 	document.querySelector('#properties-unfreeze').addEventListener('click', function(event) {
 		sendMessage('unfreezeEntity', {
+			handle: currentEntity()
+		});
+	});
+
+	document.querySelector('#properties-lock').addEventListener('click', function(event) {
+		sendMessage('lockEntity', {
+			handle: currentEntity()
+		});
+	});
+
+	document.querySelector('#properties-unlock').addEventListener('click', function(event) {
+		sendMessage('unlockEntity', {
 			handle: currentEntity()
 		});
 	});


### PR DESCRIPTION
**Description:** This PR introduces quality-of-life improvements focused on building precision and preventing accidental edits to placed props. For instance, when an editor is furnishing a house or an interior, it was previously common to accidentally select the building shell itself, leading to unintended movement or even deletion of the entire structure.

**Key Changes:**

- **Entity Locking:**
   - Added Lock/Unlock buttons to the entity Properties Menu.
   - **Movement Protection:** Locked entities cannot be moved or rotated using the mouse (gizmo) or keyboard controls.
   - **Deletion Protection:** Locked entities cannot be deleted individually via the standard delete keybind.
   - **Focus Protection:** Locked entities are ignored when trying to Focus (Alt) on an object, preventing accidental camera snapping to background props.
   - _Note: The "Delete All" function in the Database Menu will still remove locked entities to allow for a complete cleanup._
   
- **Spawn at Last Z-Coordinate:**
   - Added a modifier key for spawning. Holding CTRL (mapped to INPUT_DUCK) while spawning an entity will place it at the exact Z-coordinate (height) of the previously spawned entity.
   - This allows for easier placement of multiple objects on tables, shelves, or floating platforms without them snapping to the ground.
   
- **UI Updates:**
   - Updated index.html and script.js to include the new Lock/Unlock controls in the properties interface.

<img width="448" height="253" alt="image" src="https://github.com/user-attachments/assets/897992ad-4d21-4959-b43d-a51b2aa00d8b" />
